### PR TITLE
Solution for issue #20 

### DIFF
--- a/pinba.c
+++ b/pinba.c
@@ -2054,7 +2054,7 @@ SET_METHOD_NUM(setMemoryFootprint, memory_footprint, long, "l");
 SET_METHOD_NUM(setMemoryPeak, memory_peak, long, "l");
 SET_METHOD_NUM(setDocumentSize, document_size, long, "l");
 SET_METHOD_NUM(setStatus, status, long, "l");
-SET_METHOD_NUM(setRequestTime, request_time, float, "d");
+SET_METHOD_NUM(setRequestTime, request_time, double, "d");
 
 /* {{{ proto bool PinbaClient::setRusage(array rusage)
     */


### PR DESCRIPTION
When I try to use:

```php -r '$pc = new PinbaClient(array(ini_get("pinba.server"))); $pc->setRequestTime(0.1);'```

I've got the warning
```Warning: PinbaClient::setRequestTime(): request_time cannot be less than zero in Command line code on line 1```

That's because you use:
```SET_METHOD_NUM(setRequestTime, request_time, float, "d");```

As I know php variables use type double but you compare with type float in that macros.